### PR TITLE
Add GitHub workflow to run tests on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies and runs `npm test` on each push
- allow manually triggering the workflow with workflow_dispatch

## Testing
- npm test *(fails: npm registry returned 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca590c2ff483259be5e65175d95360